### PR TITLE
Add comprehensive logging for streaming audio debugging

### DIFF
--- a/transcription.py
+++ b/transcription.py
@@ -23,10 +23,17 @@ class TranscriptionService:
         audio_files = glob.glob(f"{config.AUDIO_QUEUE_DIR}/*.wav")
 
         if not audio_files:
-            logger.info("No audio files to process")
+            logger.info("[BATCH] No audio files to process in queue")
             return results
 
-        logger.info(f"Processing {len(audio_files)} audio files")
+        # Log details about files found
+        logger.info("=" * 60)
+        logger.info(f"[BATCH] Found {len(audio_files)} audio files to process:")
+        for file in audio_files:
+            filename = os.path.basename(file)
+            file_size_mb = os.path.getsize(file) / (1024 * 1024)
+            logger.info(f"[BATCH]   - {filename} ({file_size_mb:.2f}MB)")
+        logger.info("=" * 60)
 
         for audio_path in audio_files:
             try:
@@ -90,6 +97,8 @@ class TranscriptionService:
                 if r2_key:
                     # Delete processed audio file only if successfully saved to R2
                     os.remove(audio_path)
+                    logger.info(f"[BATCH] ✅ Successfully transcribed {filename} for user {uid}")
+                    logger.info(f"[BATCH]    Transcript preview: {transcription.text[:100]}...")
 
                     results.append(
                         {


### PR DESCRIPTION
## Summary

This PR adds detailed logging to help debug OMI device streaming issues.

## Changes

### Streaming Endpoint (`/streaming`)
- Log incoming request details (host IP, query params, content-type)
- Log raw audio bytes received from OMI device
- Log file saving success with full filepath
- Calculate and log approximate audio duration
- Add visual separators (`====`) for easier log reading

### Batch Processor
- List all files found in queue with their sizes
- Log successful transcription with preview of transcript text
- Use `[STREAMING]` and `[BATCH]` prefixes for log clarity

## Purpose

These logs will help diagnose:
- ✅ Whether OMI is reaching the server
- ✅ What data is being sent (size, format)
- ✅ If files are being saved correctly
- ✅ When batch processing occurs
- ✅ What the transcribed text contains

## Example Log Output

```
============================================================
[STREAMING] Incoming request from 192.168.1.100
[STREAMING] Query params - uid: user123, sample_rate: 16000
[STREAMING] Content-Type: application/octet-stream
[STREAMING] Validated params - uid: user123, sample_rate: 16000
[STREAMING] Received 320000 raw audio bytes from OMI device
[STREAMING] Added WAV header - total size now 320044 bytes
[STREAMING] Generated filename: streaming_user123_1234567890.wav
[STREAMING] ✅ Successfully saved audio file to: /data/audio_queue/streaming_user123_1234567890.wav
[STREAMING] File details - Size: 0.31MB, Duration: ~10.0s
[STREAMING] Audio queued for transcription - will process in 120s
============================================================
```

## Deployment

After merging, update your server:
```bash
git pull origin main
docker-compose down
docker-compose up -d
docker-compose logs -f  # Watch the new detailed logs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)