### PR TITLE
security: Bind port 8000 to localhost only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     container_name: omi-transcription
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       - GROQ_API_KEY=${GROQ_API_KEY}
       - R2_ACCOUNT_ID=${R2_ACCOUNT_ID}


### PR DESCRIPTION
External access now requires going through nginx/HTTPS. Direct access to port 8000 is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)